### PR TITLE
Remove the `pins` definition.

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -13,9 +13,6 @@ config_schema:
   - ["mqtt.server", "broker.losant.com:8883"]
   - ["mqtt.enable", true]
   - ["mqtt.ssl_ca_cert", "ca.pem"]
-  - ["pins", "o", {title: "Pins layout"}]
-  - ["pins.led", "i", -1, {title: "LED GPIO pin"}]
-  - ["pins.button", "i", -1, {title: "Button GPIO pin"}]
 
 conds:
   - when: mos.platform == "esp32"


### PR DESCRIPTION
Removed `pins` object definition. Already defined in https://github.com/mongoose-os-libs/demo-bundle/blob/350e542b307b8de2a2abd0a7087f4c83ab93beda/mos.yml#L10